### PR TITLE
プロジェクトモデルのidendifierに一意制約を追加

### DIFF
--- a/db/migrate/20241114073958_add_unique_index_to_projects_identifier.rb
+++ b/db/migrate/20241114073958_add_unique_index_to_projects_identifier.rb
@@ -1,0 +1,9 @@
+class AddUniqueIndexToProjectsIdentifier < ActiveRecord::Migration[7.2]
+  def up
+    add_index :projects, :identifier, :unique => true
+  end
+
+  def down
+    remove_index :projects, :identifier
+  end
+end


### PR DESCRIPTION
##  タイトル
Uniqueness of Project model fields is not checked sufficiently

## 説明
In the Project model, :identifier is defined as unique, but it is not guaranteed to be unique in the database.
If transactions are processed in parallel, projects with the same identifier will be created.

Therefore, we propose to add unique-index to the database to guarantee uniqueness.A patch for this purpose is attached.